### PR TITLE
Update wordpress-jail.sh

### DIFF
--- a/wordpress-jail.sh
+++ b/wordpress-jail.sh
@@ -14,7 +14,7 @@ print_err () {
 }
 
 rand() {
-  local rnum=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%()*+,-./:;<=>?@[]^_`{}~' </dev/urandom | head -c "$1" ; echo)
+  local rnum=$(LC_ALL=C tr -dc 'A-Za-z0-9!#$%()*+,-./:;<=>?@[]^_{}~' </dev/urandom | head -c "$1" ; echo)
   echo $rnum
 }
 


### PR DESCRIPTION
Avoid the backquote (`) in password generation.