### PR TITLE
Update Caddyfile for 2.5.0+

### DIFF
--- a/includes/Caddyfile
+++ b/includes/Caddyfile
@@ -22,6 +22,7 @@
     encode gzip zstd
     php_fastcgi 127.0.0.1:9000 {
         env SERVER_PORT 80
+        trusted_proxies private_ranges
     }
     file_server
 


### PR DESCRIPTION
Since caddy 2.5.0 you need to specify trusted_proxies to the wordpress caddyfile to get the CSS to load properly.

https://caddy.community/t/caddy-behind-a-reverse-proxy-use-wrong-x-forwarded-proto/16487/2